### PR TITLE
Fix Client Connection Error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,6 @@ org.gradle.daemon=false
 	loader_version=0.15.6-babric.1
 
 # Mod Properties
-	mod_version=1.0.2
+	mod_version=1.0.3
 	maven_group=net.glasslauncher.mods
 	archives_base_name=glass-networking

--- a/src/main/java/net/glasslauncher/mods/networking/GlassPacket.java
+++ b/src/main/java/net/glasslauncher/mods/networking/GlassPacket.java
@@ -1,6 +1,7 @@
 package net.glasslauncher.mods.networking;
 
 import lombok.Getter;
+import net.glasslauncher.mods.networking.mixin.accessor.NbtCompoundAccessor;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.NetworkHandler;
 import net.minecraft.network.packet.Packet;
@@ -63,7 +64,7 @@ public class GlassPacket extends Packet {
     @Override
     public void read(DataInputStream stream) {
         nbt = new NbtCompound();
-        nbt.read(stream);
+        ((NbtCompoundAccessor)nbt).invokeRead(stream);
         packetId = nbt.getString("glassnetworking:packetId");
         modId = nbt.getString("glassnetworking:modId");
     }

--- a/src/main/java/net/glasslauncher/mods/networking/mixin/accessor/NbtCompoundAccessor.java
+++ b/src/main/java/net/glasslauncher/mods/networking/mixin/accessor/NbtCompoundAccessor.java
@@ -1,0 +1,13 @@
+package net.glasslauncher.mods.networking.mixin.accessor;
+
+import net.minecraft.nbt.NbtCompound;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.io.DataInput;
+
+@Mixin(NbtCompound.class)
+public interface NbtCompoundAccessor {
+    @Invoker("read")
+    void invokeRead(DataInput input);
+}

--- a/src/main/resources/glassnetworking.accesswidener
+++ b/src/main/resources/glassnetworking.accesswidener
@@ -1,6 +1,3 @@
 accessWidener v2 named
 
 accessible field net/minecraft/client/Minecraft INSTANCE Lnet/minecraft/client/Minecraft;
-
-accessible method net/minecraft/nbt/NbtElement write (Ljava/io/DataOutput;)V
-accessible method net/minecraft/nbt/NbtCompound read (Ljava/io/DataInput;)V

--- a/src/main/resources/glassnetworking.mixins.json
+++ b/src/main/resources/glassnetworking.mixins.json
@@ -6,7 +6,8 @@
   "mixins": [
     "HandshakePacketMixin",
     "PacketHandlerMixin",
-    "PacketMixin"
+    "PacketMixin",
+    "accessor.NbtCompoundAccessor"
   ],
   "server": [
     "server.ServerLoginNetworkHandlerMixin"


### PR DESCRIPTION
Fixes this error from happening on client
```
[03:57:14] [Client read thread/ERROR] (FabricLoader) Uncaught exception in thread "Client read thread"
java.lang.IllegalAccessError: class net.glasslauncher.mods.networking.GlassPacket tried to access method 'void net.minecraft.class_8.method_630(java.io.DataInput)' (net.glasslauncher.mods.networking.GlassPacket and net.minecraft.class_8 are in unnamed module of loader net.fabricmc.loader.impl.launch.knot.KnotClassLoader @16b3fc9e)
    at net.glasslauncher.mods.networking.GlassPacket.method_806(GlassPacket.java:66) ~[glass-networking-1.0.2.jar:?]
    at net.minecraft.class_169.method_803(class_169.java:141) ~[client-intermediary.jar:?]
    at net.minecraft.class_117.method_1139(class_117.java:197) ~[client-intermediary.jar:?]
    at net.minecraft.class_117.method_1132(class_117.java:17) ~[client-intermediary.jar:?]
    at net.minecraft.class_117$4.run(class_117.java:84) ~[client-intermediary.jar:?]
```